### PR TITLE
add the simplest possible github action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,20 @@
+name: run-tests
+
+'on':
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade -e . pylint
+      - run: pylint -E castoredc_api_client


### PR DESCRIPTION
`pylint -E` will prevent the most obvious errors (variable typos and such).

this github workflow can be built upon later, maybe with things such as `black`, `mypy` and `pytest`.