### PR TITLE
Prevent instances of CastorClient overwriting each other's tokens

### DIFF
--- a/castoredc_api/client/castoredc_api_client.py
+++ b/castoredc_api/client/castoredc_api_client.py
@@ -1,9 +1,10 @@
 """Module for interacting with the Castor EDC API."""
+
+import asyncio
 import csv
 from datetime import datetime
 from itertools import chain
-import asyncio
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
 import httpx
 from httpx import HTTPStatusError
@@ -23,11 +24,6 @@ class CastorClient:
     # Necessary number of public methods to interact with API
 
     # INITIALIZATION
-    headers = {
-        "accept": "*/*",  # "application/hal+json; text/csv",
-        "Content-Type": "application/json; charset=utf-8",
-    }
-
     # Limits for server load
     max_connections = 15
     timeout = httpx.Timeout(10.0, read=60)
@@ -40,6 +36,10 @@ class CastorClient:
         # Instantiate URLs
         self.base_url = f"https://{url}/api"
         self.auth_url = f"https://{url}/oauth/token"
+        self.headers = {
+            "accept": "*/*",  # "application/hal+json; text/csv",
+            "Content-Type": "application/json; charset=utf-8",
+        }
 
         # Grab authentication token for given client
         token = self.request_auth_token(client_id, client_secret)

--- a/castoredc_api/tests/test_client.py
+++ b/castoredc_api/tests/test_client.py
@@ -27,7 +27,6 @@ def mock_auth(httpx_mock):
     return httpx_mock
 
 
-@pytest.mark.xfail
 def test_clients_are_distinct(mock_auth):
     client1 = CastorClient(
         "DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com"

--- a/castoredc_api/tests/test_client.py
+++ b/castoredc_api/tests/test_client.py
@@ -1,0 +1,39 @@
+import json
+import secrets
+
+import httpx
+import pytest
+from castoredc_api import CastorClient
+from pytest_httpx import HTTPXMock
+
+
+@pytest.fixture
+def mock_auth(httpx_mock):
+    def token_response(httpx_mock: HTTPXMock):
+        return httpx.Response(
+            status_code=200,
+            json={
+                "access_token": secrets.token_hex(32),
+                "expires_in": 18000,
+                "token_type": "Bearer",
+                "scope": "default",
+            },
+        )
+
+    httpx_mock.add_callback(
+        url="https://data.castoredc.com/oauth/token",
+        callback=token_response,
+    )
+    return httpx_mock
+
+
+@pytest.mark.xfail
+def test_clients_are_distinct(mock_auth):
+    client1 = CastorClient(
+        "DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com"
+    )
+    client2 = CastorClient(
+        "DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com"
+    )
+
+    assert client1.headers is not client2.headers

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "tqdm>=4.62.0",
         "httpx>=0.19.0",
     ],
-    tests_require=["pytest"],
+    tests_require=["pytest", "pytest-httpx"],
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`CastorClient.headers` is defined as a class attribute rather than an instance attribute.

This is a problem because authorization updates `self.headers` to set the bearer token, which means that if a user were to
create a second instance of `CastorClient`, it would overwrite/redefine the token used by the first client.

By changing headers from a class attribute to an instance attribute, the problem is avoided.

*Note: I split this up into two commits, so it's possible to see the test fail when checking out just the first commit. The test case is a bit of a special-case for functionality that is unlikely to regress, so consideration could be given to removing it. However, I made it to serve as an example/scaffolding for another upcoming change.*