### PR TITLE
Set user agent header

### DIFF
--- a/castoredc_api/client/castoredc_api_client.py
+++ b/castoredc_api/client/castoredc_api_client.py
@@ -1,9 +1,10 @@
 """Module for interacting with the Castor EDC API."""
+
+import asyncio
 import csv
 from datetime import datetime
 from itertools import chain
-import asyncio
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
 import httpx
 from httpx import HTTPStatusError
@@ -23,11 +24,6 @@ class CastorClient:
     # Necessary number of public methods to interact with API
 
     # INITIALIZATION
-    headers = {
-        "accept": "*/*",  # "application/hal+json; text/csv",
-        "Content-Type": "application/json; charset=utf-8",
-    }
-
     # Limits for server load
     max_connections = 15
     timeout = httpx.Timeout(10.0, read=60)
@@ -40,6 +36,10 @@ class CastorClient:
         # Instantiate URLs
         self.base_url = f"https://{url}/api"
         self.auth_url = f"https://{url}/oauth/token"
+        self.headers = {
+            "accept": "*/*",  # "application/hal+json; text/csv",
+            "Content-Type": "application/json; charset=utf-8",
+        }
 
         # Grab authentication token for given client
         token = self.request_auth_token(client_id, client_secret)

--- a/castoredc_api/tests/test_client.py
+++ b/castoredc_api/tests/test_client.py
@@ -27,7 +27,6 @@ def mock_auth(httpx_mock):
     return httpx_mock
 
 
-@pytest.mark.xfail
 def test_clients_are_distinct(mock_auth):
     client1 = CastorClient(
         "DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com"

--- a/castoredc_api/tests/test_client.py
+++ b/castoredc_api/tests/test_client.py
@@ -1,10 +1,16 @@
 import json
 import secrets
+import sys
 
 import httpx
 import pytest
 from castoredc_api import CastorClient
 from pytest_httpx import HTTPXMock
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata as pkg_metadata
+else:
+    import importlib_metadata as pkg_metadata
 
 
 @pytest.fixture
@@ -36,3 +42,14 @@ def test_clients_are_distinct(mock_auth):
     )
 
     assert client1.headers is not client2.headers
+
+
+def test_client_sets_correct_user_agent(httpx_mock, mock_auth):
+    # This makes an HTTP request on instantiation to exchange client secrets
+    # for a token, so there's no need to make another HTTP request in this test.
+    _ = CastorClient("DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com")
+
+    assert (
+        httpx_mock.get_request().headers["user-agent"]
+        == f"python-castoredc_api/{pkg_metadata.version('castoredc_api')}"
+    )

--- a/castoredc_api/tests/test_client.py
+++ b/castoredc_api/tests/test_client.py
@@ -1,0 +1,39 @@
+import json
+import secrets
+
+import httpx
+import pytest
+from castoredc_api import CastorClient
+from pytest_httpx import HTTPXMock
+
+
+@pytest.fixture
+def mock_auth(httpx_mock):
+    def token_response(httpx_mock: HTTPXMock):
+        return httpx.Response(
+            status_code=200,
+            json={
+                "access_token": secrets.token_hex(32),
+                "expires_in": 18000,
+                "token_type": "Bearer",
+                "scope": "default",
+            },
+        )
+
+    httpx_mock.add_callback(
+        url="https://data.castoredc.com/oauth/token",
+        callback=token_response,
+    )
+    return httpx_mock
+
+
+@pytest.mark.xfail
+def test_clients_are_distinct(mock_auth):
+    client1 = CastorClient(
+        "DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com"
+    )
+    client2 = CastorClient(
+        "DUMMY_CLIENT_ID", "DUMMY_CLIENT_SECRET", "data.castoredc.com"
+    )
+
+    assert client1.headers is not client2.headers

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "tqdm>=4.62.0",
         "httpx>=0.19.0",
     ],
-    tests_require=["pytest"],
+    tests_require=["pytest", "pytest-httpx"],
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -19,6 +19,9 @@ setup(
         "openpyxl>=3.0.7",
         "tqdm>=4.62.0",
         "httpx>=0.19.0",
+        # importlib.metadata was only introduced in Python 3.8, but the
+        # "importlib-metadata" package provides it for older Python versions.
+        'importlib-metadata >= 1.0 ; python_version < "3.8"',
     ],
     tests_require=["pytest", "pytest-httpx"],
     license="MIT",


### PR DESCRIPTION
This will allow us (Castor) to more easily distinguish/attribute traffic generated by this library in our access logs.

(My eye was caught by https://github.com/reiniervlinschoten/castoredc_api/issues/74  as I love me a good obscure bug :joy: But looking up logs is a lot easier with a distinguishable user-agent)

Making this seemingly trivial adjustment turned out slightly bigger, as it made me notice a bug that I fixed in https://github.com/reiniervlinschoten/castoredc_api/pull/76. This PR builds on top of that though as it touches the same code paths.

It also changes `request_auth_token` to reuse the same HTTPX client instead of using the httpx-module default, ensuring the same headers, limits and timeouts are used there.
