### PR TITLE
Fallback to date format if datetime format doesn't work

### DIFF
--- a/castoredc_api/study/castor_objects/castor_data_point.py
+++ b/castoredc_api/study/castor_objects/castor_data_point.py
@@ -127,9 +127,14 @@ class CastorDataPoint:
             else:
                 new_value = "Missing value not recognized"
         else:
-            new_value = pd.Period(
-                datetime.strptime(self.raw_value, "%d-%m-%Y;%H:%M"), freq="S"
-            ).strftime(datetime_format)
+            try:
+                new_value = pd.Period(
+                    datetime.strptime(self.raw_value, "%d-%m-%Y;%H:%M"), freq="S"
+                ).strftime(datetime_format)
+            except:
+                new_value = pd.Period(
+                    datetime.strptime(self.raw_value, "%d-%m-%Y"), freq="S"
+                ).strftime(datetime_format)
 
         return new_value
 


### PR DESCRIPTION
A proposed fix for #80

Another approach would be to make the preprocessing format string exposed & customizable