### PR TITLE
Reword keyerror message. Optionally pass keyerrors forward as field values

### DIFF
--- a/castoredc_api/study/castor_objects/castor_data_point.py
+++ b/castoredc_api/study/castor_objects/castor_data_point.py
@@ -212,13 +212,16 @@ class CastorDataPoint:
         # Values to names
         if value_list == [""]:
             new_values = [""]
+        elif study.pass_keyerrors:
+            new_values = [link.get(value, value) for value in value_list]
         else:
             try:
                 new_values = [link[value] for value in value_list]
             except KeyError as error:
                 raise CastorException(
-                    f"Value without label in {self.raw_value} "
-                    f"for a datapoint of field: {self.field_id} ({self.instance_of.field_name}"
+                    f"Optional value mapping failed."
+                    f"Key `{self.raw_value}` not present in the keys of optional values"
+                    f"of field: {self.field_id} ({self.instance_of.field_name})"
                 ) from error
         # Return a string, for multiple answers separate them with |
         new_value = "|".join(new_values)

--- a/castoredc_api/study/castor_study.py
+++ b/castoredc_api/study/castor_study.py
@@ -44,6 +44,7 @@ class CastorStudy:
         url: str,
         test=False,
         format_options=None,
+        pass_keyerrors=False,
     ) -> None:
         """Create a CastorStudy object."""
         self.study_id = study_id
@@ -60,6 +61,8 @@ class CastorStudy:
         if test is False:
             self.client = CastorClient(client_id, client_secret, url)
             self.client.link_study(study_id)
+        # Optionnally pass missing keys forward as field values
+        self.pass_keyerrors = pass_keyerrors
         # List of all forms in the study - structure
         self.forms_on_id = {}
         self.forms_on_name = {}

--- a/castoredc_api/study/castor_study.py
+++ b/castoredc_api/study/castor_study.py
@@ -61,7 +61,7 @@ class CastorStudy:
         if test is False:
             self.client = CastorClient(client_id, client_secret, url)
             self.client.link_study(study_id)
-        # Optionnally pass missing keys forward as field values
+        # Optionally pass missing keys forward as field values
         self.pass_keyerrors = pass_keyerrors
         # List of all forms in the study - structure
         self.forms_on_id = {}


### PR DESCRIPTION
Currently if there is a broken key in the study data a keyerror is thrown.

This does two things:
- Formats the error explanation for clarity
- Adds a `study.pass_keyerrors = True` option to mimic the way that the [R api package](https://github.com/castoredc/castoRedc) behaves in forwarding the raw key value as the field value without throwing an error